### PR TITLE
Fix Web UI API client's fetch User Details from Auth Server path

### DIFF
--- a/web/src/api-client/index.js
+++ b/web/src/api-client/index.js
@@ -21,6 +21,6 @@ export const fetchInstallation = async () => {
 };
 
 export const fetchUserInfo = async () => {
-  const response = await axios.get('/login');
+  const response = await axios.get('/login/');
   return response.data;
 };


### PR DESCRIPTION
Change web API client to fetch user details from auth server using /login/ path with trailing slash.
This should hopefully prevent the redirect being returned without the correct scheme. i.e. redirecting to `http` when on `https`.#

Addresses #5 