### PR TITLE
Change SwaggerUI docExpansion setting to "list"

### DIFF
--- a/web/src/components/catalogue-container.tsx
+++ b/web/src/components/catalogue-container.tsx
@@ -82,7 +82,7 @@ const CatalogueContainer: FunctionComponent = () => {
       </Container>
       <div className="side-by-side-column" data-testid="catalogue-container-swagger-ui">
         <CloseSpecButton />
-        <SwaggerUI url={interfaceFileContentsPath} />
+        <SwaggerUI url={interfaceFileContentsPath} docExpansion="list" />
       </div>
     </div>
   );


### PR DESCRIPTION
Change SwaggerUI docExpansion setting to "list" to show tags expanded with operation titles visible when SwaggerUI component loads. 
As per [SwaggerUI configuration documentation](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md#display).

Resolves #10 
