### PR TITLE
make catalogue manifest schema extensible

### DIFF
--- a/backend/specs/catalogue-manifest.yaml
+++ b/backend/specs/catalogue-manifest.yaml
@@ -12,7 +12,6 @@ properties:
       $ref: '#/definitions/Catalogue'
 required:
   - spectacular
-additionalProperties: false
 definitions:
   Catalogue:
     type: object
@@ -27,7 +26,6 @@ definitions:
           $ref: '#/definitions/Interface'
     required:
       - title
-    additionalProperties: false
   Interface:
     type: object
     properties:
@@ -35,7 +33,6 @@ definitions:
         $ref: '#/definitions/SpecFileLocation'
     required:
       - specFile
-    additionalProperties: false
   SpecFileLocation:
     type: object
     properties:
@@ -46,5 +43,4 @@ definitions:
         pattern: ^[^\/]+\/[^\/]+$
     required:
       - filePath
-    additionalProperties: false
 

--- a/backend/src/test/groovy/spectacular/backend/cataloguemanifest/CatalogueManifestParserTest.groovy
+++ b/backend/src/test/groovy/spectacular/backend/cataloguemanifest/CatalogueManifestParserTest.groovy
@@ -35,6 +35,7 @@ class CatalogueManifestParserTest extends Specification {
     def aCatalogueManifestWithInvalidFields = "spectacular: '0.1'\n" +
             "catalogues:\n" +
             "  testCatalogue1:\n" +
+            "    title: \"Test Catalogue 1\"\n" +
             "    randomField: 12345"
 
     def aCatalogueManifestWithMissingCatalogueTitle = "spectacular: '0.1'\n" +
@@ -79,7 +80,7 @@ class CatalogueManifestParserTest extends Specification {
         !result.error
     }
 
-    def "FindAndParseCatalogueInManifestFileContents returns parse error for unknown fields in catalogue manifest"() {
+    def "FindAndParseCatalogueInManifestFileContents accepts unknown fields in catalogue manifest to support backwards compatibility"() {
         given: "an invalid catalogue manifest YAML content"
         def yamlManifest = aCatalogueManifestWithInvalidFields
 
@@ -87,10 +88,10 @@ class CatalogueManifestParserTest extends Specification {
         def result = catalogueManifestParser.findAndParseCatalogueInManifestFileContents(yamlManifest, "testCatalogue1");
 
         then: "the catalogue is not found"
-        !result.catalogue
+        result.catalogue
 
-        and: "there is a parse error"
-        result.error == "A mapping error occurred while parsing the catalogue manifest yaml file. The following field is invalid: spectacular.backend.cataloguemanifest.model.Catalogue[\"randomField\"]"
+        and: "there is no error"
+        !result.error
     }
 
     def "FindAndParseCatalogueInManifestFileContents returns parse error for missing required fields in catalogue manifest"() {


### PR DESCRIPTION
Removes the restriction on additional properties from the catalogue manifest schema.
Resolves #23 