### PR TITLE
Add GitHub app permission requirements

### DIFF
--- a/docs/git-integration.md
+++ b/docs/git-integration.md
@@ -23,6 +23,8 @@ The following GitHub App registration values need to be set:
 - Under `Repository permissions` give the App:
   - `Read-only` access to the `Contents` item
   - `Read-only` access to the `Pull requests` item
+- Under `Organization permissions` give the App:
+  - `Read-only` access to the `Members` item
 
 Complete the rest of the registration details as appropriate and save your new App.
 

--- a/docs/git-integration.md
+++ b/docs/git-integration.md
@@ -20,7 +20,9 @@ To setup your own instance of Spectacular, you will need to register your own Gi
 
 The following GitHub App registration values need to be set:
 - `User authorization callback URL` - Set this to the URL following the following format: `<SPECTACULAR_HOST_URL>/login/github`. Where `SPECTACULAR_HOST_URL` is a URL to your installation of the Spectacular UI. For example, when running Spectacularly locally, this would be `http://localhost:8080/login/github`.
-- Under `Repository permissions` give the App `Read-only` access to the `Contents` item.
+- Under `Repository permissions` give the App:
+  - `Read-only` access to the `Contents` item
+  - `Read-only` access to the `Pull requests` item
 
 Complete the rest of the registration details as appropriate and save your new App.
 


### PR DESCRIPTION
Updating the documentation to include the required read permissions for the GitHub App setup:

- Repository `Pull request` permission to extract PR information for the spec evolution.
- Organisation `Members` permission to allow access to be determined for members of an org's teams.

This PR helps fix #27.