### PR TITLE
Add ability to hide previous versions on the Spec Evolution view

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,6 +160,7 @@ stages:
               echo "##vso[task.setVariable variable=VIDEOSEXIST]true";
             fi;
       displayName: Check artifacts exist
+      condition: always()
     - task: PublishPipelineArtifact@1
       displayName: Publish Screenshots
       condition: eq(variables.SCREENSHOTSEXIST, 'true')

--- a/docs/release-instructions.md
+++ b/docs/release-instructions.md
@@ -7,7 +7,9 @@ Check the repository's [Releases](https://github.com/specmore/spectacular/releas
 
 ## Create a build from the release tag
 Once release has been published and the tag is created, run the SpectacularCI build pipeline for the `refs/tags/vX.X.X` tag.
+
 Ensure the pipeline run has created release candidate images for both Backend and Web components with the right version.
+This can be done by running the [Spectacular Test Deploy](https://dev.azure.com/specmore/Spectacular/_build?definitionId=2&_a=summary) pipeline with the `overrideImageTag` set to the `X.X.X` version number and check that the [test site](https://spectacular-test.specmore.org/) reports the appropriate version number.
 
 ## Promote the Docker Images
 Pull, tag and push the docker images with the new version number.

--- a/integration-tests/ui-e2e/cypress/integration/end_to_end.js
+++ b/integration-tests/ui-e2e/cypress/integration/end_to_end.js
@@ -78,10 +78,22 @@ describe('End to End test without login', function() {
         // then spec evolution details are shown
         cy.get('[data-testid=spec-evolution-container]').should('be.visible')
 
-        // and 10 spec log items are shown
-        cy.get('[data-testid=log-entry-container]').should('have.length', 10)
+        // and 7 spec log entries and a previous versions label entry are shown
+        cy.get('[data-testid=log-entry-container]').should('have.length', 8)
 
-        // when the view spec button on the first PR is click
+        // when the show previous versions toggle button is clicked
+        cy.get('[data-testid=show-spec-evolution-previous-versions-toggle-button]').click()
+
+        // then 10 spec log entries and a previous versions label entry are now shown
+        cy.get('[data-testid=log-entry-container]').should('have.length', 11)
+
+        // when the show previous versions toggle button is clicked again
+        cy.get('[data-testid=show-spec-evolution-previous-versions-toggle-button]').click()
+
+        // then only 7 spec log entries and a previous versions label entry are shown again
+        cy.get('[data-testid=log-entry-container]').should('have.length', 8)
+
+        // when the view spec button on the first PR is clicked
         cy.get('[data-testid=spec-evolution-log-container] > :nth-child(1) > :nth-child(1) [data-testid=view-spec-button]').click()
 
         // then latest agree version swagger ui preview is shown

--- a/web/src/__tests__/test-data-generator/evolution-branch.ts
+++ b/web/src/__tests__/test-data-generator/evolution-branch.ts
@@ -5,12 +5,14 @@ import PullRequestGen from './pull-request';
 interface GenerateEvolutionBranchParameters {
   branchName?: string;
   numberPullRequests?: number;
+  numberPreviousVersions?: number;
   evolutionItemsOverride?: EvolutionItem[];
 }
 
 const generateEvolutionBranch = ({
   branchName = 'mainBranch',
   numberPullRequests = 0,
+  numberPreviousVersions = 0,
   evolutionItemsOverride = null,
 }: GenerateEvolutionBranchParameters = {}): EvolutionBranch => {
   let evolutionItems: EvolutionItem[] = null;
@@ -23,7 +25,12 @@ const generateEvolutionBranch = ({
       const pullRequest: PullRequest = PullRequestGen.generatePullRequest({ number: i });
       pullRequestItems.push(EvolutionItemGen.generateEvolutionItem({ ref: pullRequest.branchName, pullRequest }));
     }
-    evolutionItems = [branchHeadItem, ...pullRequestItems];
+    const previousVersionItems = [];
+    for (let i = 0; i < numberPreviousVersions; i += 1) {
+      const tag = `1.${numberPreviousVersions - i}`;
+      previousVersionItems.push(EvolutionItemGen.generateEvolutionItem({ ref: tag, tags: [tag] }));
+    }
+    evolutionItems = [branchHeadItem, ...pullRequestItems, ...previousVersionItems];
   }
   return {
     branchName,

--- a/web/src/__tests__/test-data-generator/evolution-branch.ts
+++ b/web/src/__tests__/test-data-generator/evolution-branch.ts
@@ -30,7 +30,7 @@ const generateEvolutionBranch = ({
       const tag = `1.${numberPreviousVersions - i}`;
       previousVersionItems.push(EvolutionItemGen.generateEvolutionItem({ ref: tag, tags: [tag] }));
     }
-    evolutionItems = [branchHeadItem, ...pullRequestItems, ...previousVersionItems];
+    evolutionItems = [...pullRequestItems, branchHeadItem, ...previousVersionItems];
   }
   return {
     branchName,

--- a/web/src/__tests__/test-data-generator/evolution-item.ts
+++ b/web/src/__tests__/test-data-generator/evolution-item.ts
@@ -10,8 +10,8 @@ interface GenerateEvolutionItemParameters {
 }
 
 const generateEvolutionItem = ({
-  ref = 'test-branch',
-  branchName = 'test-branch',
+  ref = 'test-ref',
+  branchName = null,
   tags = [],
   pullRequest = null,
   specItem = SpecItemGen.generateSpecItem(),

--- a/web/src/__tests__/test-data-generator/index.ts
+++ b/web/src/__tests__/test-data-generator/index.ts
@@ -1,6 +1,7 @@
 import SpecItem from './spec-item';
 import PullRequest from './pull-request';
 import Catalogue from './catalogue';
+import EvolutionBranch from './evolution-branch';
 import SpecEvolution from './spec-evolution';
 import SpecEvolutionSummary from './spec-evolution-summary';
 
@@ -10,4 +11,5 @@ export default {
   Catalogue,
   SpecEvolution,
   SpecEvolutionSummary,
+  EvolutionBranch,
 };

--- a/web/src/components/interface-container.test.js
+++ b/web/src/components/interface-container.test.js
@@ -5,7 +5,11 @@ import InterfaceDetailsMock from './interface-details';
 import SpecEvolutionMock from './spec-evolution/spec-evolution-container';
 import { renderWithRouter } from '../__tests__/test-utils';
 import {
-  CATALOGUE_CONTAINER_WITH_SPEC_LOCATION_ROUTE, VIEW_SPEC_QUERY_PARAM_NAME, SHOW_EVOLUTION_QUERY_PARAM_NAME, CreateInterfaceLocation,
+  CATALOGUE_CONTAINER_WITH_SPEC_LOCATION_ROUTE,
+  VIEW_SPEC_QUERY_PARAM_NAME,
+  SHOW_EVOLUTION_QUERY_PARAM_NAME,
+  SHOW_EVOLUTION_QUERY_PARAM_VALUES,
+  CreateInterfaceLocation,
 } from '../routes';
 import { useGetInterfaceDetails as useGetInterfaceDetailsMock } from '../backend-api-client';
 
@@ -102,7 +106,7 @@ describe('InterfaceContainer component', () => {
 
     // and show spec evolution is set
     const interfaceLocation = CreateInterfaceLocation(catalogueId, interfaceName);
-    const location = `${interfaceLocation}?${SHOW_EVOLUTION_QUERY_PARAM_NAME}=true`;
+    const location = `${interfaceLocation}?${SHOW_EVOLUTION_QUERY_PARAM_NAME}=${SHOW_EVOLUTION_QUERY_PARAM_VALUES.SHOW}`;
 
     // when interface container component renders
     const { findByTestId } = renderWithRouter(<InterfaceContainer org="test-org" />,

--- a/web/src/components/spec-evolution/spec-evolution-branch.test.js
+++ b/web/src/components/spec-evolution/spec-evolution-branch.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import SpecEvolutionBranchContainer from './spec-evolution-branch';
+import { renderWithRouter } from '../../__tests__/test-utils';
+import Generator from '../../__tests__/test-data-generator';
+import EvolutionLinesItemMock from './evolution-lines-item';
+import EvolutionItemDetailsMock from './evolution-item-details';
+
+
+// mock out the actual spec evolution items
+jest.mock('./evolution-lines-item', () => jest.fn(() => null));
+jest.mock('./evolution-item-details', () => jest.fn(() => null));
+
+afterEach(() => {
+  EvolutionLinesItemMock.mockClear();
+  EvolutionItemDetailsMock.mockClear();
+});
+
+describe('SpecEvolutionBranchContainer component', () => {
+  test('renders a previous versions item for a main branch', async () => {
+    // given an evolution branch
+    const evolutionBranch = Generator.EvolutionBranch.generateEvolutionBranch({ numberPullRequests: 1, numberPreviousVersions: 1 });
+
+    // when SpecEvolutionBranchContainer renders a main branch
+    const { getByTestId } = renderWithRouter(<SpecEvolutionBranchContainer evolutionBranch={evolutionBranch} isMain />);
+
+    // then an evolution branch container is found
+    expect(getByTestId('evolution-branch-container')).toBeInTheDocument();
+
+    // and previous versions item is found
+    expect(getByTestId('previous-versions-details-container')).toBeInTheDocument();
+
+    // and 3 EvolutionLinesItem items should have been created
+    expect(EvolutionLinesItemMock).toHaveBeenCalledTimes(3);
+
+    // and 3 EvolutionItemDetails items should have been created
+    expect(EvolutionItemDetailsMock).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('SpecEvolutionBranchContainer component', () => {
+  test('does not render a previous versions details item for a release branch and always shows previous version entries', async () => {
+    // given an evolution branch
+    const evolutionBranch = Generator.EvolutionBranch.generateEvolutionBranch({ numberPullRequests: 1, numberPreviousVersions: 1 });
+
+    // when SpecEvolutionBranchContainer renders a non main branch
+    const { queryByTestId } = renderWithRouter(<SpecEvolutionBranchContainer evolutionBranch={evolutionBranch} />);
+
+    // then an evolution branch container is found
+    expect(queryByTestId('evolution-branch-container')).toBeInTheDocument();
+
+    // and previous versions item is not found
+    expect(queryByTestId('previous-versions-details-container')).not.toBeInTheDocument();
+
+    // and 3 EvolutionLinesItem items should have been created
+    expect(EvolutionLinesItemMock).toHaveBeenCalledTimes(3);
+
+    // and 3 EvolutionItemDetails items should have been created
+    expect(EvolutionItemDetailsMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/web/src/components/spec-evolution/spec-evolution-branch.test.js
+++ b/web/src/components/spec-evolution/spec-evolution-branch.test.js
@@ -5,6 +5,10 @@ import { renderWithRouter } from '../../__tests__/test-utils';
 import Generator from '../../__tests__/test-data-generator';
 import EvolutionLinesItemMock from './evolution-lines-item';
 import EvolutionItemDetailsMock from './evolution-item-details';
+import {
+  SHOW_EVOLUTION_QUERY_PARAM_NAME,
+  SHOW_EVOLUTION_QUERY_PARAM_VALUES,
+} from '../../routes';
 
 
 // mock out the actual spec evolution items
@@ -17,7 +21,7 @@ afterEach(() => {
 });
 
 describe('SpecEvolutionBranchContainer component', () => {
-  test('renders a previous versions item for a main branch', async () => {
+  test('renders a previous versions label for a main branch', async () => {
     // given an evolution branch
     const evolutionBranch = Generator.EvolutionBranch.generateEvolutionBranch({ numberPullRequests: 1, numberPreviousVersions: 1 });
 
@@ -27,8 +31,39 @@ describe('SpecEvolutionBranchContainer component', () => {
     // then an evolution branch container is found
     expect(getByTestId('evolution-branch-container')).toBeInTheDocument();
 
-    // and previous versions item is found
+    // and previous versions label is found
     expect(getByTestId('previous-versions-details-container')).toBeInTheDocument();
+  });
+
+  test('does not render previous version items for a main branch when not set to show', async () => {
+    // given an evolution branch
+    const evolutionBranch = Generator.EvolutionBranch.generateEvolutionBranch({ numberPullRequests: 1, numberPreviousVersions: 1 });
+
+    // when SpecEvolutionBranchContainer renders a main branch without the show previous versions query parameter
+    const { getByTestId } = renderWithRouter(<SpecEvolutionBranchContainer evolutionBranch={evolutionBranch} isMain />);
+
+    // then an evolution branch container is found
+    expect(getByTestId('evolution-branch-container')).toBeInTheDocument();
+
+    // and only the PR and branch head EvolutionLinesItem items should have been created
+    expect(EvolutionLinesItemMock).toHaveBeenCalledTimes(2);
+
+    // and only the PR and branch head EvolutionItemDetails items should have been created
+    expect(EvolutionItemDetailsMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('renders previous version items for a main branch when set to show', async () => {
+    // given an evolution branch
+    const evolutionBranch = Generator.EvolutionBranch.generateEvolutionBranch({ numberPullRequests: 1, numberPreviousVersions: 1 });
+
+    // and the show previous versions query parameter is set
+    const location = `?${SHOW_EVOLUTION_QUERY_PARAM_NAME}=${SHOW_EVOLUTION_QUERY_PARAM_VALUES.SHOW_WITH_PREVIOUS_VERSIONS}`;
+
+    // when SpecEvolutionBranchContainer renders a main branch without the show previous versions query parameter
+    const { getByTestId } = renderWithRouter(<SpecEvolutionBranchContainer evolutionBranch={evolutionBranch} isMain />, location);
+
+    // then an evolution branch container is found
+    expect(getByTestId('evolution-branch-container')).toBeInTheDocument();
 
     // and 3 EvolutionLinesItem items should have been created
     expect(EvolutionLinesItemMock).toHaveBeenCalledTimes(3);
@@ -36,10 +71,8 @@ describe('SpecEvolutionBranchContainer component', () => {
     // and 3 EvolutionItemDetails items should have been created
     expect(EvolutionItemDetailsMock).toHaveBeenCalledTimes(3);
   });
-});
 
-describe('SpecEvolutionBranchContainer component', () => {
-  test('does not render a previous versions details item for a release branch and always shows previous version entries', async () => {
+  test('does not render a previous versions label for a release branch and always shows previous version entries', async () => {
     // given an evolution branch
     const evolutionBranch = Generator.EvolutionBranch.generateEvolutionBranch({ numberPullRequests: 1, numberPreviousVersions: 1 });
 
@@ -49,7 +82,7 @@ describe('SpecEvolutionBranchContainer component', () => {
     // then an evolution branch container is found
     expect(queryByTestId('evolution-branch-container')).toBeInTheDocument();
 
-    // and previous versions item is not found
+    // and previous versions label is not found
     expect(queryByTestId('previous-versions-details-container')).not.toBeInTheDocument();
 
     // and 3 EvolutionLinesItem items should have been created

--- a/web/src/components/spec-evolution/spec-evolution-branch.tsx
+++ b/web/src/components/spec-evolution/spec-evolution-branch.tsx
@@ -1,7 +1,9 @@
 import React, { FunctionComponent } from 'react';
+import { Icon, Label } from 'semantic-ui-react';
 import { EvolutionBranch, EvolutionItem } from '../../backend-api-client';
 import EvolutionLinesItem from './evolution-lines-item';
 import EvolutionItemDetails from './evolution-item-details';
+import { isShowSpecEvolutionPreviousVersions, ShowSpecEvolutionPreviousVersionsToggleButton } from '../../routes';
 
 interface EvolutionBranchProps {
   evolutionBranch: EvolutionBranch;
@@ -13,6 +15,10 @@ interface LogEntryContainerProps {
   isMain?: boolean;
 }
 
+interface PreviousVersionsLabelProps {
+  previousVersionsCount: number;
+}
+
 const LogEntryContainer: FunctionComponent<LogEntryContainerProps> = ({ evolutionItem, isMain }) => (
   <div className="item">
     <div className="log-entry-container" data-testid="log-entry-container">
@@ -22,12 +28,19 @@ const LogEntryContainer: FunctionComponent<LogEntryContainerProps> = ({ evolutio
   </div>
 );
 
-const PreviousVersionsItem: FunctionComponent = () => (
+const PreviousVersionsLabel: FunctionComponent<PreviousVersionsLabelProps> = ({ previousVersionsCount }) => (
   <div className="item">
     <div className="log-entry-container" data-testid="log-entry-container">
       <div className="line-container" />
       <div className="details-container" data-testid="previous-versions-details-container">
-        Previous Versions
+        <div className="centre">
+          <span style={{ paddingRight: '1em' }}>Previous Versions</span>
+          <Label className="old-version">
+            <Icon name="history" />
+            {previousVersionsCount}
+          </Label>
+        </div>
+        <ShowSpecEvolutionPreviousVersionsToggleButton />
       </div>
     </div>
   </div>
@@ -39,11 +52,14 @@ const SpecEvolutionBranchContainer: FunctionComponent<EvolutionBranchProps> = ({
   const headAndPrLogItems = evolutionItems.slice(0, branchHeadEvolutionItemIndex + 1).map((evolutionItem) => (
     <LogEntryContainer key={evolutionItem.ref} evolutionItem={evolutionItem} isMain={isMain} />
   ));
-  const previousVersionLogItems = evolutionItems.slice(branchHeadEvolutionItemIndex + 1).map((evolutionItem) => (
-    <LogEntryContainer key={evolutionItem.ref} evolutionItem={evolutionItem} isMain={isMain} />
-  ));
 
-  const previousVersionsEntry = isMain ? (<PreviousVersionsItem />) : null;
+  const previousVersionsCount = evolutionItems.length - branchHeadEvolutionItemIndex - 1;
+  const previousVersionsEntry = isMain ? (<PreviousVersionsLabel previousVersionsCount={previousVersionsCount} />) : null;
+  const previousVersionLogItems = !isMain || isShowSpecEvolutionPreviousVersions()
+    ? evolutionItems.slice(branchHeadEvolutionItemIndex + 1).map((evolutionItem) => (
+      <LogEntryContainer key={evolutionItem.ref} evolutionItem={evolutionItem} isMain={isMain} />
+    ))
+    : null;
 
   return (
     <div className="evolution-branch-container" data-testid="evolution-branch-container">

--- a/web/src/components/spec-evolution/spec-evolution-branch.tsx
+++ b/web/src/components/spec-evolution/spec-evolution-branch.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { EvolutionBranch } from '../../backend-api-client';
+import { EvolutionBranch, EvolutionItem } from '../../backend-api-client';
 import EvolutionLinesItem from './evolution-lines-item';
 import EvolutionItemDetails from './evolution-item-details';
 
@@ -8,21 +8,48 @@ interface EvolutionBranchProps {
   isMain?: boolean;
 }
 
-const SpecEvolutionBranchContainer: FunctionComponent<EvolutionBranchProps> = ({ evolutionBranch, isMain }) => {
-  const { evolutionItems } = evolutionBranch;
-  const logItems = evolutionItems.map((evolutionItem) => (
-    <div key={evolutionItem.ref} className="item">
-      <div className="log-entry-container" data-testid="log-entry-container">
-        <EvolutionLinesItem evolutionItem={evolutionItem} isMain={isMain} />
-        <EvolutionItemDetails evolutionItem={evolutionItem} isMain={isMain} />
-        {/* <OpenSpecItemContentPageButton specItem={specItem} /> */}
+interface LogEntryContainerProps {
+  evolutionItem: EvolutionItem;
+  isMain?: boolean;
+}
+
+const LogEntryContainer: FunctionComponent<LogEntryContainerProps> = ({ evolutionItem, isMain }) => (
+  <div className="item">
+    <div className="log-entry-container" data-testid="log-entry-container">
+      <EvolutionLinesItem evolutionItem={evolutionItem} isMain={isMain} />
+      <EvolutionItemDetails evolutionItem={evolutionItem} isMain={isMain} />
+    </div>
+  </div>
+);
+
+const PreviousVersionsItem: FunctionComponent = () => (
+  <div className="item">
+    <div className="log-entry-container" data-testid="log-entry-container">
+      <div className="line-container" />
+      <div className="details-container" data-testid="previous-versions-details-container">
+        Previous Versions
       </div>
     </div>
+  </div>
+);
+
+const SpecEvolutionBranchContainer: FunctionComponent<EvolutionBranchProps> = ({ evolutionBranch, isMain }) => {
+  const { evolutionItems } = evolutionBranch;
+  const branchHeadEvolutionItemIndex = evolutionItems.findIndex((evolutionItem) => evolutionItem.branchName);
+  const headAndPrLogItems = evolutionItems.slice(0, branchHeadEvolutionItemIndex + 1).map((evolutionItem) => (
+    <LogEntryContainer key={evolutionItem.ref} evolutionItem={evolutionItem} isMain={isMain} />
+  ));
+  const previousVersionLogItems = evolutionItems.slice(branchHeadEvolutionItemIndex + 1).map((evolutionItem) => (
+    <LogEntryContainer key={evolutionItem.ref} evolutionItem={evolutionItem} isMain={isMain} />
   ));
 
+  const previousVersionsEntry = isMain ? (<PreviousVersionsItem />) : null;
+
   return (
-    <div className="evolution-branch-container">
-      {logItems}
+    <div className="evolution-branch-container" data-testid="evolution-branch-container">
+      {headAndPrLogItems}
+      {previousVersionsEntry}
+      {previousVersionLogItems}
     </div>
   );
 };

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -15,6 +15,10 @@ export const CreateInterfaceLocation = (encodedId: string, interfaceName: string
 
 export const VIEW_SPEC_QUERY_PARAM_NAME = 'ref';
 export const SHOW_EVOLUTION_QUERY_PARAM_NAME = 'show-evolution';
+export enum SHOW_EVOLUTION_QUERY_PARAM_VALUES {
+  SHOW = 'true',
+  SHOW_WITH_PREVIOUS_VERSIONS = 'with-previous-versions',
+}
 
 export const useQuery = (): URLSearchParams => new URLSearchParams(useLocation().search);
 
@@ -111,9 +115,11 @@ export const CloseSpecButton: FunctionComponent = () => {
 
 export const getCurrentSpecRefViewed = (): string => useQuery().get(VIEW_SPEC_QUERY_PARAM_NAME);
 
+export const isShowSpecEvolution = (): boolean => useQuery().get(SHOW_EVOLUTION_QUERY_PARAM_NAME) != null;
+
 export const ViewSpecEvolutionLinkButton: FunctionComponent = () => {
-  const expandSpecEvolutionLocation = addQueryParam(SHOW_EVOLUTION_QUERY_PARAM_NAME, 'true');
-  const isSelected = useQuery().get(SHOW_EVOLUTION_QUERY_PARAM_NAME) === 'true';
+  const expandSpecEvolutionLocation = addQueryParam(SHOW_EVOLUTION_QUERY_PARAM_NAME, SHOW_EVOLUTION_QUERY_PARAM_VALUES.SHOW);
+  const isSelected = isShowSpecEvolution();
 
   return (
     <Button
@@ -148,8 +154,30 @@ export const CloseSpecEvolutionButton: FunctionComponent = () => {
   );
 };
 
-export const isShowSpecEvolution = (): boolean => useQuery().get(SHOW_EVOLUTION_QUERY_PARAM_NAME) === 'true';
+export const isShowSpecEvolutionPreviousVersions = (): boolean => useQuery().get(SHOW_EVOLUTION_QUERY_PARAM_NAME)
+=== SHOW_EVOLUTION_QUERY_PARAM_VALUES.SHOW_WITH_PREVIOUS_VERSIONS;
 
+export const ShowSpecEvolutionPreviousVersionsToggleButton: FunctionComponent = () => {
+  const isShowing = isShowSpecEvolutionPreviousVersions();
+  const newQueryParamValue = isShowing ? SHOW_EVOLUTION_QUERY_PARAM_VALUES.SHOW
+    : SHOW_EVOLUTION_QUERY_PARAM_VALUES.SHOW_WITH_PREVIOUS_VERSIONS;
+  const toggleLocation = addQueryParam(SHOW_EVOLUTION_QUERY_PARAM_NAME, newQueryParamValue);
+  const angleIconDirection = isShowing ? 'angle down' : 'angle right';
+
+  return (
+    <Button
+      icon
+      circular
+      size="mini"
+      as={Link}
+      to={toggleLocation}
+      data-testid="show-spec-evolution-previous-versions-toggle-button"
+      floated="right"
+    >
+      <Icon name={angleIconDirection} />
+    </Button>
+  );
+};
 
 interface OpenSpecItemContentPageButtonProps {
   specItem: SpecItem;


### PR DESCRIPTION
Added new "previous versions" entry to the Spec Evolution list just under the main branch head entry.
This entry has:
- the count of previous version items that are just created from tags on the main branch.
- a toggle button to hide the previous version entries below it.

Screen shots:
- Previous versions toggle to hidden
![image](https://user-images.githubusercontent.com/11502284/117537375-60759180-aff8-11eb-9961-ac977dc1af12.png)
- Previous versions toggle to shown
![image](https://user-images.githubusercontent.com/11502284/117537389-771be880-aff8-11eb-9d7a-937df30002e4.png)

This resolves #31 .
