### PR TITLE
Change NGINX config to reuse existing x-spec-installation-id header

### DIFF
--- a/web/web.template.conf
+++ b/web/web.template.conf
@@ -1,6 +1,17 @@
+log_format with_header '$remote_addr - $remote_user [$time_local] '
+                       '"$request" $status $body_bytes_sent '
+                       '"$http_referer" "$http_user_agent" "$http_x_spec_installation_id"';
+
+map $http_x_spec_installation_id $spectacular_installation_id {
+    default   $http_x_spec_installation_id;
+    ""        "${GITHUB_APP_INSTALLATION_ID}";
+}
+
 server {
     listen       80 default_server;
     server_name  localhost;
+
+    access_log /var/log/nginx/access.log with_header;
 
     location / {
         root   /usr/share/nginx/html;
@@ -14,7 +25,7 @@ server {
 
     location /api/ {
       proxy_pass      ${API_LOCATION}/;
-      proxy_set_header        x-spec-installation-id    ${GITHUB_APP_INSTALLATION_ID};
+      proxy_set_header        x-spec-installation-id    $spectacular_installation_id;
     }
 
     location /login/ {


### PR DESCRIPTION
This PR introduces a change to the NGINX config of the web component for proxying request to the `/api/` route to the backend API component. The proxying behaviour will now reuse the value in a `x-spec-installation-id` header on incoming requests instead of always replacing it with the default value in the `GITHUB_APP_INSTALLATION_ID` environment variable set on the web container.

Also introduced a change to the access log format to log any `x-spec-installation-id` header value received on requests.