### PR TITLE
App v2 route backwards compatibility

### DIFF
--- a/backend/specs/backend-api.yaml
+++ b/backend/specs/backend-api.yaml
@@ -74,6 +74,13 @@ paths:
         - App
       description: Gets the installations accessible to the currently logged in user
       operationId: getInstallations
+      parameters:
+        - name: catalogueEncodedId
+          in: query
+          description: A base64 encoded id of a Catalogue that belongs to an installation
+          schema:
+            type: string
+            format: byte
       responses:
         '200':
           description: Successful operation

--- a/backend/src/main/java/spectacular/backend/app/InstallationService.java
+++ b/backend/src/main/java/spectacular/backend/app/InstallationService.java
@@ -1,10 +1,13 @@
 package spectacular.backend.app;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import spectacular.backend.api.model.GetInstallationsResult;
 import spectacular.backend.api.model.Installation;
+import spectacular.backend.common.CatalogueId;
 import spectacular.backend.github.app.AppApiClient;
 
 @Service
@@ -34,9 +37,11 @@ public class InstallationService {
    * @param installationIds that are to be used to retrieve the installation details
    * @return a GetInstallationsResult containing all the retrieved installations
    */
-  public GetInstallationsResult getInstallations(List<Long> installationIds) {
+  public GetInstallationsResult getInstallations(List<Long> installationIds, Optional<CatalogueId> catalogueId) {
     final var installations = installationIds.stream()
         .map(installationId -> this.appApiClient.getAppInstallation(installationId.toString()))
+        .filter(installation -> catalogueId.isEmpty() ||
+            Objects.equals(catalogueId.get().getRepositoryId().getOwner(), installation.getAccount().getLogin()))
         .map(this.installationMapper::mapInstallation)
         .collect(Collectors.toList());
     return new GetInstallationsResult().installations(installations);

--- a/backend/src/main/java/spectacular/backend/catalogues/CataloguesController.java
+++ b/backend/src/main/java/spectacular/backend/catalogues/CataloguesController.java
@@ -54,9 +54,7 @@ public class CataloguesController implements CataloguesApi {
   public ResponseEntity<GetCatalogueResult> getCatalogue(Integer installationId, byte[] encoded) {
     final var jwt = validateRequest(installationId);
 
-    var decodedBytes = Base64.getDecoder().decode(encoded);
-    var combinedId = new String(decodedBytes);
-    var catalogueId = CatalogueId.createFrom(combinedId);
+    var catalogueId = CatalogueId.createFromBase64(encoded);
 
     var getCatalogueForUserResult = catalogueService.getCatalogueForUser(catalogueId, jwt.getSubject());
 
@@ -70,9 +68,7 @@ public class CataloguesController implements CataloguesApi {
   public ResponseEntity<GetInterfaceResult> getInterfaceDetails(Integer installationId, byte[] encodedId, String interfaceName) {
     final var jwt = validateRequest(installationId);
 
-    var decodedBytes = Base64.getDecoder().decode(encodedId);
-    var combinedId = new String(decodedBytes);
-    var catalogueId = CatalogueId.createFrom(combinedId);
+    var catalogueId = CatalogueId.createFromBase64(encodedId);
 
     var getInterfaceDetailsResult = this.catalogueService.getInterfaceDetails(catalogueId, interfaceName, jwt.getSubject());
 
@@ -88,9 +84,7 @@ public class CataloguesController implements CataloguesApi {
                                                          @Valid String ref) {
     final var jwt = validateRequest(installationId);
 
-    var decodedBytes = Base64.getDecoder().decode(encodedId);
-    var combinedId = new String(decodedBytes);
-    var catalogueId = CatalogueId.createFrom(combinedId);
+    var catalogueId = CatalogueId.createFromBase64(encodedId);
 
     try {
       var getInterfaceFileContentsResult = this.catalogueService.getInterfaceFileContents(

--- a/backend/src/main/java/spectacular/backend/common/CatalogueId.java
+++ b/backend/src/main/java/spectacular/backend/common/CatalogueId.java
@@ -1,5 +1,6 @@
 package spectacular.backend.common;
 
+import java.util.Base64;
 import java.util.Objects;
 import javax.validation.constraints.NotNull;
 import spectacular.backend.cataloguemanifest.model.Catalogue;
@@ -73,6 +74,12 @@ public class CatalogueId extends CatalogueManifestId {
 
 
     return new CatalogueId(repository, path, name);
+  }
+
+  public static CatalogueId createFromBase64(byte[] encodedId) {
+    var decodedBytes = Base64.getDecoder().decode(encodedId);
+    var combinedId = new String(decodedBytes);
+    return createFrom(combinedId);
   }
 
   @Override

--- a/backend/src/test/groovy/spectacular/backend/app/InstallationServiceTest.groovy
+++ b/backend/src/test/groovy/spectacular/backend/app/InstallationServiceTest.groovy
@@ -1,0 +1,97 @@
+package spectacular.backend.app
+
+import org.springframework.util.StringUtils
+import spectacular.backend.api.model.Catalogue
+import spectacular.backend.api.model.GetInterfaceResult
+import spectacular.backend.api.model.SpecEvolutionSummary
+import spectacular.backend.cataloguemanifest.model.Interface
+import spectacular.backend.common.CatalogueId
+import spectacular.backend.common.RepositoryId
+import spectacular.backend.github.app.AppApiClient
+import spectacular.backend.github.domain.Account
+import spectacular.backend.github.domain.Installation
+import spock.lang.Specification
+
+class InstallationServiceTest extends Specification {
+    def appApiClient = Mock(AppApiClient)
+    def installationMapper = Mock(InstallationMapper)
+    def installationService = new InstallationService(appApiClient, installationMapper)
+
+    def aCatalogueId() {
+        def catalogueRepo = new RepositoryId("test-owner","test-repo987")
+        def catalogueManifestFile = "spectacular-config.yml";
+        def catalogueName = "testCatalogue1"
+        return new CatalogueId(catalogueRepo, catalogueManifestFile, catalogueName)
+    }
+
+    def "get installations for all installationIds"() {
+        given: "a no catalogueId"
+        Optional<CatalogueId> catalogueId = Optional.empty()
+
+        and: "a list of installation ids to search for"
+        def installationIds = [1l,2l]
+
+        and: "installations for each id"
+        def account1 = Mock(Account)
+        def installation1 = Mock(Installation)
+        installation1.getAccount() >> account1
+        def mappedInstallation1 = Mock(spectacular.backend.api.model.Installation)
+
+        def account2 = Mock(Account)
+        def installation2 = Mock(Installation)
+        installation2.getAccount() >> account2
+        def mappedInstallation2 = Mock(spectacular.backend.api.model.Installation)
+
+        when: "the searching for installations with the catalogue id"
+        def result = installationService.getInstallations(installationIds, catalogueId)
+
+        then: "the github app rest api is called for each installation id"
+        1 * appApiClient.getAppInstallation(installationIds.get(0).toString()) >> installation1
+        1 * appApiClient.getAppInstallation(installationIds.get(1).toString()) >> installation2
+
+        and: "both installations are  mapped"
+        1 * installationMapper.mapInstallation(installation1) >> mappedInstallation1
+        1 * installationMapper.mapInstallation(installation2) >> mappedInstallation2
+
+        and: "both installations are returned"
+        result.installations.size() == 2
+        result.installations.get(0) == mappedInstallation1
+        result.installations.get(1) == mappedInstallation2
+    }
+
+    def "get installation for a given catalogueId and list of installationIds"() {
+        given: "a catalogueId"
+        def catalogueId = Optional.of(aCatalogueId())
+
+        and: "a list of installation ids to search for"
+        def installationIds = [1l,2l]
+
+        and: "installations for each id"
+        def account1 = Mock(Account)
+        def installation1 = Mock(Installation)
+        installation1.getAccount() >> account1
+
+        def account2 = Mock(Account)
+        def installation2 = Mock(Installation)
+        installation2.getAccount() >> account2
+        def mappedInstallation = Mock(spectacular.backend.api.model.Installation)
+
+        and: "only one installation has the same owner name as the Catalogue's Repo"
+        account1.getLogin() >> "different"
+        account2.getLogin() >> "test-owner"
+
+        when: "the searching for installations with the catalogue id"
+        def result = installationService.getInstallations(installationIds, catalogueId)
+
+        then: "the github app rest api is called for each installation id"
+        1 * appApiClient.getAppInstallation(installationIds.get(0).toString()) >> installation1
+        1 * appApiClient.getAppInstallation(installationIds.get(1).toString()) >> installation2
+
+        and: "only the matching installation is mapped"
+        1 * installationMapper.mapInstallation(installation2) >> mappedInstallation
+
+        and: "only the matching installation is returned"
+        result.installations.size() == 1
+        result.installations.get(0) == mappedInstallation
+    }
+}

--- a/web/src/components/app/app-container.test.js
+++ b/web/src/components/app/app-container.test.js
@@ -6,8 +6,6 @@ import {
   useGetInstallations as useGetInstallationsMock,
   useGetAppDetails as useGetAppDetailsMock,
 } from '../../backend-api-client';
-import MenuBarMock from '../menu-bar';
-import FooterBarMock from '../footer-bar';
 import InstallationContainerMock from '../installation-container';
 
 jest.mock('../../backend-api-client');
@@ -21,8 +19,14 @@ jest.mock('../footer-bar', () => jest.fn(() => null));
 // mock out the actual installation-container
 jest.mock('../installation-container', () => jest.fn(() => null));
 
+afterEach(() => {
+  useGetAppDetailsMock.mockClear();
+  useGetInstallationsMock.mockClear();
+  InstallationContainerMock.mockClear();
+});
+
 describe('AppContainer component', () => {
-  test('retrieves the installationId for old catalogue location and redirects to appropriate new installation location', async () => {
+  test('retrieves the installationId for an old catalogue location and redirects to appropriate new installation location', async () => {
     // given a catalogue encodedId
     const encodedId = 'test-encodedId';
 
@@ -38,6 +42,60 @@ describe('AppContainer component', () => {
 
     useGetAppDetailsMock.mockReturnValue(getAppDetailsResult);
 
+    // and a mocked successful installations query response for the given encodedId
+    const useGetInstallationsResult = {
+      data: {
+        installations: [
+          {
+            id: 1234,
+          },
+        ],
+      },
+    };
+
+    useGetInstallationsMock.mockReturnValue(useGetInstallationsResult);
+
+    // when app container component renders with the old catalogue container location
+    const { getByTestId } = renderWithRouter(<AppContainer />, oldCatalogueContainerLocation);
+
+    // then a app container is found
+    expect(getByTestId('app-container')).toBeInTheDocument();
+
+    // and it gets the app details
+    expect(useGetAppDetailsMock).toHaveBeenCalledTimes(1);
+
+    // and it tries to find an installation for the encodedId
+    expect(useGetInstallationsMock).toHaveBeenCalledWith({ queryParams: { catalogueEncodedId: encodedId } });
+
+    // and it tried to render the installation-container
+    expect(InstallationContainerMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('fails to find the installationId for an old catalogue location and shows an error', async () => {
+    // given a catalogue encodedId
+    const encodedId = 'test-encodedId';
+
+    // and an old catalogue container location
+    const oldCatalogueContainerLocation = `/catalogue/${encodedId}`;
+
+    // and a mocked successful app details response
+    const getAppDetailsResult = {
+      data: {
+        clientId: 'test-client-id',
+      },
+    };
+
+    useGetAppDetailsMock.mockReturnValue(getAppDetailsResult);
+
+    // and a mocked successful installations query response for the given encodedId
+    const useGetInstallationsResult = {
+      data: {
+        installations: [],
+      },
+    };
+
+    useGetInstallationsMock.mockReturnValue(useGetInstallationsResult);
+
     // when app container component renders with the old catalogue container location
     const { getByTestId, getByText } = renderWithRouter(<AppContainer />, oldCatalogueContainerLocation);
 
@@ -46,6 +104,58 @@ describe('AppContainer component', () => {
 
     // and it gets the app details
     expect(useGetAppDetailsMock).toHaveBeenCalledTimes(1);
+
+    // and it tries to find an installation for the encodedId
+    expect(useGetInstallationsMock).toHaveBeenCalledWith({ queryParams: { catalogueEncodedId: encodedId } });
+
+    // and it does not render the installation-container
+    expect(InstallationContainerMock).toHaveBeenCalledTimes(0);
+
+    // and it shows an error message
+    expect(getByText('The URL you have used is no longer support in this version.')).toBeInTheDocument();
+  });
+
+  test('retrieves the installationId for an old interface location and redirects to appropriate new installation location', async () => {
+    // given a catalogue encodedId and interfaceName
+    const encodedId = 'test-encodedId';
+    const interfaceName = 'testInterface123';
+
+    // and an old catalogue container location
+    const oldCatalogueContainerLocation = `/catalogue/${encodedId}/interface/${interfaceName}?ref=test-tag`;
+
+    // and a mocked successful app details response
+    const getAppDetailsResult = {
+      data: {
+        clientId: 'test-client-id',
+      },
+    };
+
+    useGetAppDetailsMock.mockReturnValue(getAppDetailsResult);
+
+    // and a mocked successful installations query response for the given encodedId
+    const useGetInstallationsResult = {
+      data: {
+        installations: [
+          {
+            id: 1234,
+          },
+        ],
+      },
+    };
+
+    useGetInstallationsMock.mockReturnValue(useGetInstallationsResult);
+
+    // when app container component renders with the old catalogue container location
+    const { getByTestId } = renderWithRouter(<AppContainer />, oldCatalogueContainerLocation);
+
+    // then a app container is found
+    expect(getByTestId('app-container')).toBeInTheDocument();
+
+    // and it gets the app details
+    expect(useGetAppDetailsMock).toHaveBeenCalledTimes(1);
+
+    // and it tries to find an installation for the encodedId
+    expect(useGetInstallationsMock).toHaveBeenCalledWith({ queryParams: { catalogueEncodedId: encodedId } });
 
     // and it tried to render the installation-container
     expect(InstallationContainerMock).toHaveBeenCalledTimes(1);

--- a/web/src/components/app/app-container.test.js
+++ b/web/src/components/app/app-container.test.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import AppContainer from './app-container';
+import { renderWithRouter } from '../../__tests__/test-utils';
+import {
+  useGetInstallations as useGetInstallationsMock,
+  useGetAppDetails as useGetAppDetailsMock,
+} from '../../backend-api-client';
+import MenuBarMock from '../menu-bar';
+import FooterBarMock from '../footer-bar';
+import InstallationContainerMock from '../installation-container';
+
+jest.mock('../../backend-api-client');
+
+// mock out the actual menu-bar
+jest.mock('../menu-bar', () => jest.fn(() => null));
+
+// mock out the actual footer-bar
+jest.mock('../footer-bar', () => jest.fn(() => null));
+
+// mock out the actual installation-container
+jest.mock('../installation-container', () => jest.fn(() => null));
+
+describe('AppContainer component', () => {
+  test('retrieves the installationId for old catalogue location and redirects to appropriate new installation location', async () => {
+    // given a catalogue encodedId
+    const encodedId = 'test-encodedId';
+
+    // and an old catalogue container location
+    const oldCatalogueContainerLocation = `/catalogue/${encodedId}`;
+
+    // and a mocked successful app details response
+    const getAppDetailsResult = {
+      data: {
+        clientId: 'test-client-id',
+      },
+    };
+
+    useGetAppDetailsMock.mockReturnValue(getAppDetailsResult);
+
+    // when app container component renders with the old catalogue container location
+    const { getByTestId, getByText } = renderWithRouter(<AppContainer />, oldCatalogueContainerLocation);
+
+    // then a app container is found
+    expect(getByTestId('app-container')).toBeInTheDocument();
+
+    // and it gets the app details
+    expect(useGetAppDetailsMock).toHaveBeenCalledTimes(1);
+
+    // and it tried to render the installation-container
+    expect(InstallationContainerMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/app/app-container.tsx
+++ b/web/src/components/app/app-container.tsx
@@ -2,19 +2,34 @@ import React, { FunctionComponent } from 'react';
 import {
   Dimmer, Loader, Message, Container,
 } from 'semantic-ui-react';
-import { Switch, Route } from 'react-router-dom';
+import {
+  Switch,
+  Route,
+  useParams,
+  useHistory,
+  Redirect,
+} from 'react-router-dom';
 import EmptyWelcomeItemImage from '../../assets/images/empty-catalogue-item.png';
 import InstallationSelectionContainer from '../installation-selection-container';
 import InstallationContainer from '../installation-container';
 import MenuBar from '../menu-bar';
 import FooterBar from '../footer-bar';
 import GitHubLogin from '../login/github-login';
-import { GITHUB_LOGIN_ROUTE, INSTALLATION_CONTAINER_ROUTE, INSTALLATION_LIST_ROUTE } from '../../routes';
-import { useGetAppDetails } from '../../backend-api-client';
+import {
+  GITHUB_LOGIN_ROUTE,
+  INSTALLATION_CONTAINER_ROUTE,
+  INSTALLATION_LIST_ROUTE,
+  OLD_V2_CATALOGUE_CONTAINER_ROUTE,
+  OldV2CatalogueContainerWithSpecLocationRouteParams,
+  OLD_V2_CATALOGUE_CONTAINER_WITH_SPEC_LOCATION_ROUTE,
+  CreateCatalogueContainerLocation,
+  CreateInterfaceLocation,
+} from '../../routes';
+import { useGetAppDetails, useGetInstallations } from '../../backend-api-client';
 import NotFound from '../not-found';
 
 const AppContainerLoading: FunctionComponent = () => (
-  <Container text>
+  <Container text style={{ paddingTop: '5em' }}>
     <Dimmer inverted active>
       <Loader content="Loading" />
     </Dimmer>
@@ -33,6 +48,32 @@ const AppContainerError: FunctionComponent<AppContainerErrorProps> = ({ errorMes
     </Message>
   </Container>
 );
+
+const ResolveInstallationContainer: FunctionComponent = () => {
+  const { encodedId, interfaceName } = useParams<OldV2CatalogueContainerWithSpecLocationRouteParams>();
+  const getInstallations = useGetInstallations({ queryParams: { catalogueEncodedId: encodedId } });
+  const { data: getInstallationsResult, loading, error } = getInstallations;
+  const history = useHistory();
+
+  if (loading) {
+    return (<AppContainerLoading />);
+  }
+
+  if (error) {
+    return (<AppContainerError errorMessage={error.message} />);
+  }
+
+  if (getInstallationsResult.installations.length > 0) {
+    const installationId = getInstallationsResult.installations[0].id;
+    let location = CreateCatalogueContainerLocation(installationId, encodedId);
+    if (interfaceName) {
+      location = CreateInterfaceLocation(installationId, encodedId, interfaceName);
+    }
+    return (<Redirect to={location + history.location.search} />);
+  }
+
+  return (<AppContainerError errorMessage="The URL you have used is no longer support in this version." />);
+};
 
 const AppContainer: FunctionComponent = () => {
   const getAppDetails = useGetAppDetails({});
@@ -56,6 +97,9 @@ const AppContainer: FunctionComponent = () => {
           <MenuBar />
           <div className="main-content" data-testid="app-container">
             <Switch>
+              <Route exact path={[OLD_V2_CATALOGUE_CONTAINER_ROUTE, OLD_V2_CATALOGUE_CONTAINER_WITH_SPEC_LOCATION_ROUTE]}>
+                <ResolveInstallationContainer />
+              </Route>
               <Route exact path={INSTALLATION_LIST_ROUTE}>
                 <InstallationSelectionContainer />
               </Route>

--- a/web/src/components/app/app-container.tsx
+++ b/web/src/components/app/app-container.tsx
@@ -54,7 +54,7 @@ const AppContainer: FunctionComponent = () => {
       <Route path="*">
         <div className="content-container">
           <MenuBar />
-          <div className="main-content">
+          <div className="main-content" data-testid="app-container">
             <Switch>
               <Route exact path={INSTALLATION_LIST_ROUTE}>
                 <InstallationSelectionContainer />

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -20,7 +20,14 @@ export const CreateInterfaceLocation = (installationId: number, encodedId: strin
   `/org/${installationId}/catalogue/${encodedId}/interface/${interfaceName}/`
 );
 
+export interface OldV2CatalogueContainerRouteParams {
+  encodedId: string
+}
 export const OLD_V2_CATALOGUE_CONTAINER_ROUTE = '/catalogue/:encodedId';
+
+export interface OldV2CatalogueContainerWithSpecLocationRouteParams extends OldV2CatalogueContainerRouteParams {
+  interfaceName: string,
+}
 export const OLD_V2_CATALOGUE_CONTAINER_WITH_SPEC_LOCATION_ROUTE = '/catalogue/:encodedId/interface/:interfaceName';
 
 export const LOGIN_REDIRECT_RETURN_TO_PARAM_NAME = 'backTo';

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -20,6 +20,9 @@ export const CreateInterfaceLocation = (installationId: number, encodedId: strin
   `/org/${installationId}/catalogue/${encodedId}/interface/${interfaceName}/`
 );
 
+export const OLD_V2_CATALOGUE_CONTAINER_ROUTE = '/catalogue/:encodedId';
+export const OLD_V2_CATALOGUE_CONTAINER_WITH_SPEC_LOCATION_ROUTE = '/catalogue/:encodedId/interface/:interfaceName';
+
 export const LOGIN_REDIRECT_RETURN_TO_PARAM_NAME = 'backTo';
 
 export const VIEW_SPEC_QUERY_PARAM_NAME = 'ref';


### PR DESCRIPTION
Added a feature to allow old v1 URLs without the new installation id in the route to be redirected to the appropriate v2 URL by determining the installation id using the repository owner name in the encoded catalogue id.